### PR TITLE
feat: containerize and auto-deploy to vps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.git

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: deploy
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ssh to VPS and run site deploy script
+        run: |
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/key
+          chmod 600 ~/.ssh/key
+          ssh-keyscan -p 2222 mathdro.id >> ~/.ssh/known_hosts 2>/dev/null
+          ssh -i ~/.ssh/key -p 2222 root@mathdro.id deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+# ponytail: node 16 because next 9 predates node 18; upgrade base image with the app
+FROM node:16-alpine
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+COPY . .
+RUN yarn build
+EXPOSE 3000
+CMD ["yarn", "start"]


### PR DESCRIPTION
## What does this change?

Adds a Dockerfile and a deploy workflow so pushes to master automatically deploy the site to the VPS that mathdro.id now points at.

## Why is it needed?

DNS moved from Vercel to a self-hosted VPS; the site needs a container build and a deploy path there. Closes #308

## How does it work?

- `Dockerfile` - node:16-alpine (Next 9 predates node 18), yarn build, `next start` on 3000. The VPS compose stack (mathdroid/mathdroid-wish) builds it from the server-side checkout and Caddy reverse-proxies mathdro.id to it
- `.github/workflows/deploy.yml` - on push to master, SSH to the VPS with a key restricted via authorized_keys `command=` to the site deploy script (pull + rebuild only the site service)

## How was it tested?

The image was built and run on the VPS: HTTP 200 on /, correct page title. The workflow's key and script are already wired; the loop runs on merge.

## Before merging

- [x] Tests pass locally (image build + serve verified on VPS)
- [x] Self-reviewed the diff
- [x] Docs/comments updated if needed
- [x] No secrets or debug code left in

Note: /api/latest-tweet-url needs TWITTER_* env vars, provided on the VPS via an optional untracked env file - not part of this diff.