### PR TITLE
feat: full-bleed drawing page, drop A4 frame

### DIFF
--- a/src/app/canvas.tsx
+++ b/src/app/canvas.tsx
@@ -19,20 +19,19 @@ export default function Canvas() {
     const canvas = canvasRef.current!;
     const ctx = canvas.getContext("2d")!;
 
-    const scale = () => canvas.width / devicePixelRatio / 1000;
-
+    // ponytail: strokes are normalized per-axis to the viewport, so they
+    // stretch a bit between screen shapes; fine for doodles
     const drawStroke = (s: Stroke) => {
-      const k = scale() * devicePixelRatio;
-      ctx.setTransform(k, 0, 0, k, 0, 0);
-      ctx.lineWidth = 3;
+      ctx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+      const w = canvas.width / devicePixelRatio;
+      const h = canvas.height / devicePixelRatio;
+      ctx.lineWidth = 2.5;
       ctx.lineCap = "round";
       ctx.lineJoin = "round";
       ctx.strokeStyle = s.color;
       ctx.beginPath();
       s.points.forEach(([x, y], i) => {
-        const px = x * 1000;
-        const py = y * 1414;
-        i === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py);
+        i === 0 ? ctx.moveTo(x * w, y * h) : ctx.lineTo(x * w, y * h);
       });
       ctx.stroke();
     };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
           minHeight: "100dvh",
           display: "grid",
           placeItems: "center",
-          background: "#eae7e0",
+          background: "#fbf9f4",
           color: "#222",
         }}
       >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,11 +4,8 @@ export default function Page() {
   return (
     <main
       style={{
-        position: "relative",
-        width: "min(94vw, calc(94dvh / 1.414))",
-        aspectRatio: "1000 / 1414",
-        background: "#fbf9f4",
-        boxShadow: "0 1px 3px rgba(0,0,0,0.12), 0 8px 24px rgba(0,0,0,0.08)",
+        position: "fixed",
+        inset: 0,
         display: "grid",
         placeItems: "center",
       }}


### PR DESCRIPTION
## What
The paper now fills the whole viewport again - no fixed-aspect sheet, no desk background, no shadow. The canvas covers the screen and strokes are normalized per-axis to the viewport (slight stretch between screen shapes, fine for doodles; noted with a ponytail comment). Discord's daily render keeps its portrait page look.

## How tested
Built clean; drew on the live-reloaded page in a browser and verified strokes persist and render round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)