### PR TITLE
fix: remove ssh mentions from opengraph

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,8 +11,7 @@ export const metadata: Metadata = {
   openGraph: {
     siteName: "mathdro.id",
     title: "This page is intentionally left blank.",
-    description:
-      "This page is intentionally left blank. Nothing is missing. For the interactive edition: ssh mathdro.id",
+    description: "Nothing is missing.",
   },
 };
 

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -25,16 +25,6 @@ export default async function OpengraphImage() {
         <div style={{ fontSize: 52, letterSpacing: 1 }}>
           This page is intentionally left blank.
         </div>
-        <div
-          style={{
-            position: "absolute",
-            bottom: 48,
-            fontSize: 28,
-            color: "#888",
-          }}
-        >
-          ssh mathdro.id
-        </div>
       </div>
     ),
     {


### PR DESCRIPTION
OG image is just the sentence again; og:description is now "Nothing is missing." The ssh hint stays in the console log and the SERP meta description only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)