### PR TITLE
feat: per-ip stroke rate limit, keep text above drawings

### DIFF
--- a/src/app/api/strokes/route.ts
+++ b/src/app/api/strokes/route.ts
@@ -34,9 +34,25 @@ function valid(body: any): body is Stroke & { client: string } {
   );
 }
 
+// ponytail: in-memory per-ip sliding window, resets on restart; single instance
+const hits: Map<string, number[]> = ((globalThis as any).__strokeHits ??=
+  new Map());
+
+function rateLimited(ip: string) {
+  if (hits.size > 10_000) hits.clear();
+  const now = Date.now();
+  const recent = (hits.get(ip) ?? []).filter((t) => now - t < 60_000);
+  recent.push(now);
+  hits.set(ip, recent);
+  return recent.length > 20;
+}
+
 export async function POST(req: Request) {
   const body = await req.json().catch(() => null);
   if (!valid(body)) return new Response("bad stroke", { status: 400 });
+
+  const ip = req.headers.get("x-forwarded-for")?.split(",")[0].trim() ?? "?";
+  if (rateLimited(ip)) return new Response("slow down", { status: 429 });
 
   const day = today();
   // ponytail: crude flood cap instead of per-IP rate limiting; add real limiting if it gets griefed

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,9 @@ export default function Page() {
           letterSpacing: "0.02em",
           textAlign: "center",
           userSelect: "none",
+          // above the canvas so drawings never cover it; clicks pass through
+          zIndex: 1,
+          pointerEvents: "none",
         }}
       >
         This page is intentionally left blank.

--- a/src/lib/daily.tsx
+++ b/src/lib/daily.tsx
@@ -31,9 +31,6 @@ export async function renderDay(day: string, strokes: Stroke[]) {
           position: "relative",
         }}
       >
-        <div style={{ fontSize: 26, letterSpacing: 0.5 }}>
-          This page is intentionally left blank.
-        </div>
         <svg
           width={PAGE.w}
           height={PAGE.h}
@@ -52,6 +49,10 @@ export async function renderDay(day: string, strokes: Stroke[]) {
             />
           ))}
         </svg>
+        {/* after the svg so drawings never cover the text, matching the live page */}
+        <div style={{ fontSize: 26, letterSpacing: 0.5 }}>
+          This page is intentionally left blank.
+        </div>
         <div
           style={{
             position: "absolute",


### PR DESCRIPTION
## What does this change?

Limits stroke POSTs to 20 per minute per IP, and paints "This page is intentionally left blank." above the drawings on both the live page and the daily PNG.

## Why is it needed?

Today's page was flooded to the 20k global cap by a single actor, which bricked drawing for everyone else. And drawings could cover the page text. Closes #320.

## How does it work?

- `src/app/api/strokes/route.ts`: in-memory sliding window keyed on the first `X-Forwarded-For` hop (Caddy sets it); 21st stroke in a minute gets a 429. Resets on restart, single-instance deploy.
- `src/app/page.tsx`: the text gets `zIndex: 1` and `pointerEvents: none`, so it sits above the canvas but you can still draw through it.
- `src/lib/daily.tsx`: text moved after the svg so it paints on top in the rendered PNG too.

## How was it tested?

- 25 rapid posts from one IP against the dev server: 20x 200 then 5x 429; a post from a different IP still 200s.
- `tsc --noEmit` clean.

## Before merging

- [x] Tests pass locally
- [x] Self-reviewed the diff
- [x] No secrets or debug code left in