### PR TITLE
feat: rolling 10k render window, admin-only discord wipe button

### DIFF
--- a/src/app/api/discord/route.ts
+++ b/src/app/api/discord/route.ts
@@ -1,0 +1,51 @@
+import { clearStrokes, today } from "@/lib/db";
+import { publish } from "@/lib/bus";
+
+export const dynamic = "force-dynamic";
+
+const hex = (s: string) =>
+  Uint8Array.from(s.match(/../g)!.map((b) => parseInt(b, 16)));
+
+// Discord signs every request; reject anything we can't verify with the app public key.
+async function verified(req: Request, body: string) {
+  const sig = req.headers.get("x-signature-ed25519");
+  const ts = req.headers.get("x-signature-timestamp");
+  const key = process.env.DISCORD_PUBLIC_KEY;
+  if (!sig || !ts || !key) return false;
+  const pub = await crypto.subtle.importKey(
+    "raw",
+    hex(key),
+    { name: "Ed25519" },
+    false,
+    ["verify"],
+  );
+  return crypto.subtle.verify(
+    "Ed25519",
+    pub,
+    hex(sig),
+    new TextEncoder().encode(ts + body),
+  );
+}
+
+const ephemeral = (content: string) =>
+  Response.json({ type: 4, data: { content, flags: 64 } });
+
+export async function POST(req: Request) {
+  const body = await req.text();
+  if (!(await verified(req, body)))
+    return new Response("bad signature", { status: 401 });
+
+  const i = JSON.parse(body);
+  if (i.type === 1) return Response.json({ type: 1 }); // PING -> PONG
+
+  if (i.type === 3 && i.data?.custom_id === "wipe") {
+    const userId = i.member?.user?.id ?? i.user?.id;
+    if (userId !== process.env.ADMIN_DISCORD_ID)
+      return ephemeral("this button isn't for you.");
+    clearStrokes(today());
+    publish({ type: "clear" });
+    return ephemeral("wiped today's drawings.");
+  }
+
+  return ephemeral("unhandled.");
+}

--- a/src/app/api/report/route.ts
+++ b/src/app/api/report/route.ts
@@ -1,4 +1,4 @@
-import { getStrokes, today } from "@/lib/db";
+import { getStrokes, RENDER_LIMIT, today } from "@/lib/db";
 import { renderDay } from "@/lib/daily";
 
 export const dynamic = "force-dynamic";
@@ -8,28 +8,54 @@ const g = globalThis as unknown as { __lastReport?: number };
 
 export async function POST() {
   const url = process.env.DISCORD_WEBHOOK_URL;
-  if (!url) return new Response("not configured", { status: 503 });
+  const bot = process.env.DISCORD_BOT_TOKEN;
+  const channel = process.env.DISCORD_CHANNEL_ID;
+  if (!url && !(bot && channel))
+    return new Response("not configured", { status: 503 });
 
   if (Date.now() - (g.__lastReport ?? 0) < 3_600_000)
     return new Response("already reported recently", { status: 429 });
   g.__lastReport = Date.now();
 
   const day = today();
-  const png = await (await renderDay(day, getStrokes(day))).arrayBuffer();
+  const png = await (
+    await renderDay(day, getStrokes(day, RENDER_LIMIT))
+  ).arrayBuffer();
+
+  // A working "Wipe" button needs an app-owned message, so it only appears when
+  // the bot is configured; the plain webhook falls back to the curl command.
+  const useBot = Boolean(bot && channel);
+  const payload = useBot
+    ? {
+        content: `A visitor reported the drawing on ${day}.`,
+        components: [
+          {
+            type: 1,
+            components: [
+              { type: 2, style: 4, label: "Wipe drawings", custom_id: "wipe" },
+            ],
+          },
+        ],
+      }
+    : {
+        content: `A visitor reported the drawing on ${day}. Wipe it with:\n\`curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" https://mathdro.id/api/strokes\``,
+      };
+
   const form = new FormData();
-  form.append(
-    "payload_json",
-    JSON.stringify({
-      content: `A visitor reported the drawing on ${day}. Wipe it with:\n\`curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" https://mathdro.id/api/strokes\``,
-    }),
-  );
+  form.append("payload_json", JSON.stringify(payload));
   form.append(
     "files[0]",
     new Blob([png], { type: "image/png" }),
     `report-${day}.png`,
   );
 
-  const res = await fetch(url, { method: "POST", body: form });
+  const res = useBot
+    ? await fetch(`https://discord.com/api/v10/channels/${channel}/messages`, {
+        method: "POST",
+        headers: { Authorization: `Bot ${bot}` },
+        body: form,
+      })
+    : await fetch(url!, { method: "POST", body: form });
   if (!res.ok) {
     g.__lastReport = 0; // let someone retry if discord failed
     return new Response("report failed", { status: 502 });

--- a/src/app/api/strokes/route.ts
+++ b/src/app/api/strokes/route.ts
@@ -2,6 +2,7 @@ import {
   addStroke,
   clearStrokes,
   getStrokes,
+  RENDER_LIMIT,
   strokeCount,
   today,
   type Stroke,
@@ -13,7 +14,7 @@ export const dynamic = "force-dynamic";
 
 export async function GET() {
   const day = today();
-  return Response.json({ day, strokes: getStrokes(day) });
+  return Response.json({ day, strokes: getStrokes(day, RENDER_LIMIT) });
 }
 
 function valid(body: any): body is Stroke & { client: string } {

--- a/src/app/canvas.tsx
+++ b/src/app/canvas.tsx
@@ -21,6 +21,14 @@ export default function Canvas() {
     const canvas = canvasRef.current!;
     const ctx = canvas.getContext("2d")!;
 
+    // rolling window: keep only the most recent 10k strokes in memory
+    const CAP = 10_000;
+    const push = (s: Stroke) => {
+      strokes.current.push(s);
+      if (strokes.current.length > CAP)
+        strokes.current.splice(0, strokes.current.length - CAP);
+    };
+
     // ponytail: strokes are normalized per-axis to the viewport, so they
     // stretch a bit between screen shapes; fine for doodles
     const drawStroke = (s: Stroke) => {
@@ -69,7 +77,7 @@ export default function Canvas() {
         return;
       }
       if (s.client === clientId.current) return;
-      strokes.current.push(s);
+      push(s);
       drawStroke(s);
     };
 
@@ -100,7 +108,7 @@ export default function Canvas() {
       current.current = null;
       if (!pts || pts.length < 2) return;
       const stroke = { color: colorRef.current, points: pts };
-      strokes.current.push(stroke);
+      push(stroke);
       fetch("/api/strokes", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/src/lib/daily.tsx
+++ b/src/lib/daily.tsx
@@ -1,7 +1,14 @@
 import { ImageResponse } from "next/og";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { getStrokes, isPosted, markPosted, yesterday, type Stroke } from "./db";
+import {
+  getStrokes,
+  isPosted,
+  markPosted,
+  RENDER_LIMIT,
+  yesterday,
+  type Stroke,
+} from "./db";
 
 const PAGE = { w: 1000, h: 1414 };
 
@@ -80,7 +87,7 @@ async function postDrawingOfTheDay() {
 
   const day = yesterday();
   if (isPosted(day)) return;
-  const strokes = getStrokes(day);
+  const strokes = getStrokes(day, RENDER_LIMIT);
   if (strokes.length === 0) {
     markPosted(day); // nothing drawn, nothing to post
     return;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -37,12 +37,22 @@ export function addStroke(day: string, stroke: Stroke) {
   );
 }
 
-export function getStrokes(day: string): Stroke[] {
-  return db
-    .prepare("SELECT color, points FROM strokes WHERE day = ? ORDER BY id")
-    .all(day)
-    .map((r: any) => ({ color: r.color, points: JSON.parse(r.points) }));
+// with a limit, returns the most recent `limit` strokes in draw order (oldest first)
+export function getStrokes(day: string, limit?: number): Stroke[] {
+  const rows = limit
+    ? db
+        .prepare(
+          "SELECT color, points FROM strokes WHERE day = ? ORDER BY id DESC LIMIT ?",
+        )
+        .all(day, limit)
+        .reverse()
+    : db
+        .prepare("SELECT color, points FROM strokes WHERE day = ? ORDER BY id")
+        .all(day);
+  return rows.map((r: any) => ({ color: r.color, points: JSON.parse(r.points) }));
 }
+
+export const RENDER_LIMIT = 10_000;
 
 export function strokeCount(day: string): number {
   return (


### PR DESCRIPTION
## What does this change?

Caps rendering to a rolling window of the most recent 10k strokes, and adds a Discord "Wipe drawings" button on the report message that only the admin can use.

## Why is it needed?

A full day can hold up to 20k strokes (the flood cap); loading and redrawing all of them is wasteful. And wiping should be one click from the Discord alert, without exposing the admin token or letting other channel members trigger it. Closes the follow-up in #318 discussion.

## How does it work?

- `src/lib/db.ts`: `getStrokes(day, limit?)` returns the most recent `limit` strokes in draw order. `RENDER_LIMIT = 10_000`.
- `src/app/api/strokes/route.ts`, `src/lib/daily.tsx`, `src/app/api/report/route.ts`: use `RENDER_LIMIT`. `src/app/canvas.tsx` trims its in-memory buffer to 10k so long-lived sessions stay bounded.
- `src/app/api/discord/route.ts`: new Discord interactions endpoint. Verifies the Ed25519 signature with Node webcrypto (no deps), answers PING, and on the `wipe` button checks the clicker's user id against `ADMIN_DISCORD_ID` before clearing today's strokes and broadcasting the SSE clear. Non-admins get an ephemeral refusal.
- `src/app/api/report/route.ts`: when `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` are set it posts the report via the bot so the button renders; otherwise it falls back to the existing webhook + curl command.

New env (all optional; feature is dormant without them): `DISCORD_PUBLIC_KEY`, `DISCORD_BOT_TOKEN`, `DISCORD_CHANNEL_ID`, `ADMIN_DISCORD_ID`.

## How was it tested?

- Interaction endpoint against a dev server with a generated keypair: valid PING -> PONG, forged signature -> 401, non-admin `wipe` click refused with strokes left intact, admin click wipes. (self-check script)
- Rolling window query returns the most recent 10 of 15 in oldest-first order. (self-check script)
- `tsc --noEmit` and `next build` clean.

## Before merging

- [x] Tests pass locally
- [x] Self-reviewed the diff
- [x] No secrets or debug code left in
- [ ] Discord app env set on jp-001 (see PR discussion)